### PR TITLE
Add DNS lookup tool

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,13 +2,14 @@
 
 ## ✅ Completed
 - [x] Scaffold Flutter multi-platform app and router
-- [x] Implement `PingService` and `PingPage` 
+- [x] Implement `PingService` and `PingPage`
 - [x] Pass static analysis; produce Linux build
 - [x] Implement basic tabs (add/close/activate) with `TabsController` and `TabsBar`
 - [x] Wire tabs into `AppScaffold` and nav rail to open routes as tabs
 - [x] Fix provider scope issues and deprecated UI colors
 - [x] Add Traceroute tool (next most common after ping)
 - [x] Create reusable `AppScaffold` widget for consistent tool page layout
+- [x] Add DNS Lookup tool
 
 ## 🚧 In Progress
 - [ ] Implement remaining network tools (port scan, DNS, WHOIS, routes, firewall, pcap, syslog, UPnP, etc.)
@@ -16,7 +17,6 @@
 - [ ] Implement persistent state (Hive/shared_preferences) once plugin constraint is resolved
 
 ## 📋 Next Priority Items
-- [ ] Add DNS Lookup tool
 - [ ] Add Port Scanner tool
 - [ ] Improve tab persistence and state management
 - [ ] Add keyboard shortcuts (Ctrl+T for new tab, Ctrl+W to close, etc.)
@@ -48,6 +48,6 @@
 
 ---
 
-**Current Status**: Ping and Traceroute tools implemented with working tab system. Ready to add DNS and Port Scanner tools.
-**Next Target**: DNS Lookup tool implementation
-**Recent Progress**: Added TracerouteService, TraceroutePage, and AppScaffold for consistent UI
+**Current Status**: Ping, Traceroute, and DNS Lookup tools implemented with working tab system. Ready to add Port Scanner tool.
+**Next Target**: Port Scanner tool implementation
+**Recent Progress**: Added DnsLookupService, DnsLookupPage, and navigation updates for DNS tool

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'services/ping_service.dart';
 import 'state/tabs.dart';
 import 'widgets/app_scaffold.dart';
 import 'pages/traceroute_page.dart';
+import 'pages/dns_lookup_page.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -31,6 +32,10 @@ class NoctoolfApp extends StatelessWidget {
         GoRoute(
           path: '/traceroute',
           builder: (context, state) => const TraceroutePage(),
+        ),
+        GoRoute(
+          path: '/dns',
+          builder: (context, state) => const DnsLookupPage(),
         ),
       ],
     );

--- a/lib/pages/dns_lookup_page.dart
+++ b/lib/pages/dns_lookup_page.dart
@@ -1,0 +1,114 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import '../services/dns_lookup_service.dart';
+import '../widgets/app_scaffold.dart';
+
+class DnsLookupPage extends StatefulWidget {
+  const DnsLookupPage({super.key});
+
+  @override
+  State<DnsLookupPage> createState() => _DnsLookupPageState();
+}
+
+class _DnsLookupPageState extends State<DnsLookupPage> {
+  final TextEditingController hostController = TextEditingController(text: 'example.com');
+  bool loading = false;
+  List<InternetAddress> results = [];
+  String? error;
+
+  @override
+  void dispose() {
+    hostController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _lookup() async {
+    final host = hostController.text.trim();
+    if (host.isEmpty) return;
+    setState(() {
+      loading = true;
+      results = [];
+      error = null;
+    });
+    try {
+      final svc = DnsLookupService();
+      final res = await svc.lookup(host);
+      setState(() {
+        results = res.addresses;
+      });
+    } catch (e) {
+      setState(() {
+        error = e.toString();
+      });
+    } finally {
+      setState(() {
+        loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppScaffold(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('DNS Lookup Tool', style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                SizedBox(
+                  width: 260,
+                  child: TextField(
+                    controller: hostController,
+                    decoration: const InputDecoration(labelText: 'Host (e.g., example.com)'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                FilledButton(
+                  onPressed: loading ? null : _lookup,
+                  child: const Text('Lookup'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: Card(
+                clipBehavior: Clip.antiAlias,
+                child: Builder(
+                  builder: (context) {
+                    if (loading) {
+                      return const Center(child: CircularProgressIndicator());
+                    }
+                    if (error != null) {
+                      return Center(child: Text(error!, style: const TextStyle(color: Colors.red)));
+                    }
+                    if (results.isEmpty) {
+                      return const Center(
+                        child: Text('No results'),
+                      );
+                    }
+                    return ListView.separated(
+                      itemCount: results.length,
+                      separatorBuilder: (_, __) => const Divider(height: 1),
+                      itemBuilder: (context, index) {
+                        final addr = results[index];
+                        return ListTile(
+                          dense: true,
+                          title: Text(addr.address),
+                          subtitle: Text(addr.type.name),
+                        );
+                      },
+                    );
+                  },
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/dns_lookup_service.dart
+++ b/lib/services/dns_lookup_service.dart
@@ -1,0 +1,14 @@
+import 'dart:io';
+
+class DnsLookupResult {
+  final String host;
+  final List<InternetAddress> addresses;
+  DnsLookupResult({required this.host, required this.addresses});
+}
+
+class DnsLookupService {
+  Future<DnsLookupResult> lookup(String host) async {
+    final addresses = await InternetAddress.lookup(host);
+    return DnsLookupResult(host: host, addresses: addresses);
+  }
+}

--- a/lib/widgets/app_scaffold.dart
+++ b/lib/widgets/app_scaffold.dart
@@ -30,6 +30,11 @@ class AppScaffold extends StatelessWidget {
             tooltip: 'Traceroute',
             onPressed: () => context.go('/traceroute'),
           ),
+          IconButton(
+            icon: const Icon(Icons.dns_outlined),
+            tooltip: 'DNS Lookup',
+            onPressed: () => context.go('/dns'),
+          ),
         ],
       ),
       body: Column(
@@ -55,6 +60,10 @@ class AppScaffold extends StatelessWidget {
                       icon: Icon(Icons.compass_calibration_outlined),
                       label: Text('Traceroute'),
                     ),
+                    NavigationRailDestination(
+                      icon: Icon(Icons.dns_outlined),
+                      label: Text('DNS Lookup'),
+                    ),
                   ],
                   selectedIndex: _selectedIndexForPath(GoRouterState.of(context).uri.toString()),
                   onDestinationSelected: (idx) {
@@ -69,6 +78,10 @@ class AppScaffold extends StatelessWidget {
                     }
                     if (idx == 2) {
                       final t = tabs.addTab('Traceroute', '/traceroute');
+                      context.go(t.route);
+                    }
+                    if (idx == 3) {
+                      final t = tabs.addTab('DNS Lookup', '/dns');
                       context.go(t.route);
                     }
                   },
@@ -87,6 +100,7 @@ class AppScaffold extends StatelessWidget {
   int _selectedIndexForPath(String path) {
     if (path.startsWith('/ping')) return 1;
     if (path.startsWith('/traceroute')) return 2;
+    if (path.startsWith('/dns')) return 3;
     return 0;
   }
 }


### PR DESCRIPTION
## Summary
- add DNS lookup service and page
- wire DNS tool into router, app bar, and navigation rail
- mark DNS lookup as complete in TODO ledger

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a94a0e0248324877c9794fee4fc64